### PR TITLE
Handle empty aggregations correctly.

### DIFF
--- a/lookup_test.go
+++ b/lookup_test.go
@@ -83,6 +83,20 @@ func (s *S) TestAggregableLookupString_Complex(c *C) {
 	c.Assert(value.Interface(), DeepEquals, 42)
 }
 
+func (s *S) TestAggregableLookup_EmptySlice(c *C) {
+	fixture := [][]MyStruct{{}}
+	value, err := LookupString(fixture, "String")
+	c.Assert(err, IsNil)
+	c.Assert(value.Interface().([]string), DeepEquals, []string{})
+}
+
+func (s *S) TestAggregableLookup_EmptyMap(c *C) {
+	fixture := map[string]*MyStruct{}
+	value, err := LookupString(fixture, "Map")
+	c.Assert(err, IsNil)
+	c.Assert(value.Interface().([]map[string]int), DeepEquals, []map[string]int{})
+}
+
 func (s *S) TestMergeValue(c *C) {
 	v := mergeValue([]reflect.Value{reflect.ValueOf("qux"), reflect.ValueOf("foo")})
 	c.Assert(v.Interface(), DeepEquals, []string{"qux", "foo"})


### PR DESCRIPTION
Right now, if you have something like this:

```
lookup.Lookup([]map[string]int{
    {"foo": 1, "bar": 2},
    {"foo": 3},
}, "foo")
```

it aggregates every map and return `[]int{1, 3}`. But if the aggregated object is empty:

```
lookup.Lookup([]map[string]int{}, "foo")
```

it panics. It should return `[]int{}` instead.
