### PR TITLE
Fix lookup of ptr to slice

### DIFF
--- a/lookup.go
+++ b/lookup.go
@@ -76,7 +76,7 @@ func lookup(i interface{}, caseInsensitive bool, path ...string) (reflect.Value,
 
 func getValueByName(v reflect.Value, key string, caseInsensitive bool) (reflect.Value, error) {
 	var value reflect.Value
-	var index int
+	var index int = -1
 	var err error
 
 	key, index, err = parseIndex(key)
@@ -122,6 +122,10 @@ func getValueByName(v reflect.Value, key string, caseInsensitive bool) (reflect.
 	}
 
 	if index != -1 {
+		if value.Kind() == reflect.Ptr {
+			value = value.Elem()
+		}
+
 		if value.Type().Kind() != reflect.Slice {
 			return reflect.Value{}, ErrInvalidIndexUsage
 		}

--- a/lookup_test.go
+++ b/lookup_test.go
@@ -215,6 +215,23 @@ func (s *S) TestLookup_Map_CaseInsensitive_FirstMatch(c *C) {
 	c.Assert(value.Int(), Equals, int64(1))
 }
 
+func (s *S) TestLookup_ListPtr(c *C) {
+	type Inner struct {
+		Value string
+	}
+
+	type Outer struct {
+		Values *[]Inner
+	}
+
+	values := []Inner{{Value: "first"}, {Value: "second"}}
+	data := Outer{Values: &values}
+
+	value, err := LookupStringI(data, "Values[0].Value")
+	c.Assert(err, IsNil)
+	c.Assert(value.String(), Equals, "first")
+}
+
 func ExampleLookupString() {
 	type Cast struct {
 		Actor, Role string


### PR DESCRIPTION
```go
type Inner struct {
	Value string
}
type Outer struct {
	Values *[]Inner
}
// ...
LookupStringI(data, "Values[0].Value")
```
see tests for more details