### PR TITLE
Dereference value before trying to access index

### DIFF
--- a/lookup.go
+++ b/lookup.go
@@ -120,6 +120,10 @@ func getValueByName(v reflect.Value, key string, caseInsensitive bool) (reflect.
 	if !value.IsValid() {
 		return reflect.Value{}, ErrKeyNotFound
 	}
+	
+	if value.Kind() == reflect.Ptr || value.Kind() == reflect.Interface {
+		value = value.Elem()
+	}
 
 	if index != -1 {
 		if value.Kind() == reflect.Ptr {
@@ -131,10 +135,6 @@ func getValueByName(v reflect.Value, key string, caseInsensitive bool) (reflect.
 		}
 
 		value = value.Index(index)
-	}
-
-	if value.Kind() == reflect.Ptr || value.Kind() == reflect.Interface {
-		value = value.Elem()
 	}
 
 	return value, nil

--- a/lookup.go
+++ b/lookup.go
@@ -126,10 +126,6 @@ func getValueByName(v reflect.Value, key string, caseInsensitive bool) (reflect.
 	}
 
 	if index != -1 {
-		if value.Kind() == reflect.Ptr {
-			value = value.Elem()
-		}
-
 		if value.Type().Kind() != reflect.Slice {
 			return reflect.Value{}, ErrInvalidIndexUsage
 		}

--- a/lookup_test.go
+++ b/lookup_test.go
@@ -232,6 +232,16 @@ func (s *S) TestLookup_ListPtr(c *C) {
 	c.Assert(value.String(), Equals, "first")
 }
 
+func (s *S) TestLookup_ListInterface(c *C) {
+	data := map[string]interface{}{
+		"values": []string{"first", "second"}
+	}
+
+	value, err := LookupStringI(data, "values[0]")
+	c.Assert(err, IsNil)
+	c.Assert(value.String(), Equals, "first")
+}
+
 func ExampleLookupString() {
 	type Cast struct {
 		Actor, Role string

--- a/lookup_test.go
+++ b/lookup_test.go
@@ -234,7 +234,7 @@ func (s *S) TestLookup_ListPtr(c *C) {
 
 func (s *S) TestLookup_ListInterface(c *C) {
 	data := map[string]interface{}{
-		"values": []string{"first", "second"}
+		"values": []string{"first","second"},
 	}
 
 	value, err := LookupStringI(data, "values[0]")


### PR DESCRIPTION
The nested slice can be a pointer or interface, so the check `value.Type().Kind() != reflect.Slice` can fail if it is not dereferenced beforehand.

This PR simply moves the dereferencing above the index access