### PR TITLE
Fix index handling on interface

### DIFF
--- a/lookup.go
+++ b/lookup.go
@@ -85,7 +85,14 @@ func getValueByName(v reflect.Value, key string, caseInsensitive bool) (reflect.
 	}
 	switch v.Kind() {
 	case reflect.Ptr, reflect.Interface:
-		return getValueByName(v.Elem(), key, caseInsensitive)
+		value, err := getValueByName(v.Elem(), key, caseInsensitive)
+		if err != nil {
+			return value, err
+		}
+		if index != -1 {
+			value = value.Index(index)
+		}
+		return value, nil
 	case reflect.Struct:
 		value = v.FieldByName(key)
 
@@ -120,7 +127,7 @@ func getValueByName(v reflect.Value, key string, caseInsensitive bool) (reflect.
 	if !value.IsValid() {
 		return reflect.Value{}, ErrKeyNotFound
 	}
-	
+
 	if value.Kind() == reflect.Ptr || value.Kind() == reflect.Interface {
 		value = value.Elem()
 	}

--- a/lookup.go
+++ b/lookup.go
@@ -120,6 +120,10 @@ func getValueByName(v reflect.Value, key string, caseInsensitive bool) (reflect.
 	if !value.IsValid() {
 		return reflect.Value{}, ErrKeyNotFound
 	}
+	
+	if value.Kind() == reflect.Ptr || value.Kind() == reflect.Interface {
+		value = value.Elem()
+	}
 
 	if index != -1 {
 		if value.Kind() == reflect.Ptr {
@@ -131,10 +135,6 @@ func getValueByName(v reflect.Value, key string, caseInsensitive bool) (reflect.
 		}
 
 		value = value.Index(index)
-	}
-
-	if value.Kind() == reflect.Ptr || value.Kind() == reflect.Interface {
-		value = value.Elem()
 	}
 
 	return value, nil

--- a/lookup.go
+++ b/lookup.go
@@ -126,10 +126,6 @@ func getValueByName(v reflect.Value, key string, caseInsensitive bool) (reflect.
 	}
 
 	if index != -1 {
-		if value.Kind() == reflect.Ptr {
-			value = value.Elem()
-		}
-
 		if value.Type().Kind() != reflect.Slice {
 			return reflect.Value{}, ErrInvalidIndexUsage
 		}

--- a/lookup_test.go
+++ b/lookup_test.go
@@ -232,6 +232,16 @@ func (s *S) TestLookup_ListPtr(c *C) {
 	c.Assert(value.String(), Equals, "first")
 }
 
+func (s *S) TestLookup_ListInterface(c *C) {
+	data := map[string]interface{}{
+		"values": []string{"first", "second"}
+	}
+
+	value, err := LookupStringI(data, "values[0]")
+	c.Assert(err, IsNil)
+	c.Assert(value.String(), Equals, "first")
+}
+
 func ExampleLookupString() {
 	type Cast struct {
 		Actor, Role string

--- a/lookup_test.go
+++ b/lookup_test.go
@@ -234,7 +234,7 @@ func (s *S) TestLookup_ListPtr(c *C) {
 
 func (s *S) TestLookup_ListInterface(c *C) {
 	data := map[string]interface{}{
-		"values": []string{"first", "second"}
+		"values": []string{"first","second"},
 	}
 
 	value, err := LookupStringI(data, "values[0]")

--- a/lookup_test.go
+++ b/lookup_test.go
@@ -84,7 +84,7 @@ func (s *S) TestAggregableLookup_StructNested(c *C) {
 func (s *S) TestAggregableLookupString_Complex(c *C) {
 	value, err := LookupString(structFixture, "StructSlice.StructSlice[0].String")
 	c.Assert(err, IsNil)
-	c.Assert(value.Interface(), DeepEquals, []string{"bar", "foo", "qux", "baz"})
+	c.Assert(value.Interface(), DeepEquals, []string{"bar", "qux"})
 
 	value, err = LookupString(structFixture, "StructSlice[0].Map.foo")
 	c.Assert(err, IsNil)


### PR DESCRIPTION
When querying list of maps, we can lose the index in some situation.
There is actually a test for it which seems incorrect. This tries to
fix it.

This sits on top of #5 .