### PR TITLE
fix panic in lookup for multiple maps

### DIFF
--- a/lookup.go
+++ b/lookup.go
@@ -194,7 +194,6 @@ func mergeValue(values []reflect.Value) reflect.Value {
 
 	sample := values[0]
 	mergeable := isMergeable(sample)
-
 	t := sample.Type()
 	if mergeable {
 		t = t.Elem()
@@ -236,12 +235,11 @@ func isAggregable(v reflect.Value) bool {
 }
 
 func isMergeable(v reflect.Value) bool {
-	k := v.Kind()
-	return k == reflect.Map || k == reflect.Slice
+	return v.Kind() == reflect.Slice
 }
 
 func hasIndex(s string) bool {
-	return strings.Index(s, IndexOpenChar) != -1
+	return strings.Contains(s, IndexOpenChar)
 }
 
 func parseIndex(s string) (string, int, error) {

--- a/lookup_test.go
+++ b/lookup_test.go
@@ -97,6 +97,15 @@ func (s *S) TestAggregableLookupString_Complex(c *C) {
 	value, err = LookupString(mapComplexFixture, "list.baz")
 	c.Assert(err, IsNil)
 	c.Assert(value.Interface(), DeepEquals, []int{1, 2, 3})
+
+	value, err = LookupString(mapComplexFixture, "list")
+	c.Assert(err, IsNil)
+	c.Assert(value.Interface(), DeepEquals, []map[string]interface{}{
+		{"baz": 1},
+		{"baz": 2},
+		{"baz": 3},
+	})
+
 }
 
 func (s *S) TestAggregableLookup_EmptySlice(c *C) {


### PR DESCRIPTION
When the lookup results in multiple maps there was an issue in the `mergeValue` function and maps were marked as mergeable, but then handled as if they were slices. Because of that, a panic was raised.

This PR fixes that behavior by making them not mergeable instead of throwing a panic.